### PR TITLE
Error handling testing and improvements

### DIFF
--- a/lib/bus.js
+++ b/lib/bus.js
@@ -200,6 +200,9 @@ module.exports = function bus(conn, opts) {
           // try and find a matching method
           for (const ifaceName of Object.keys(obj)) {
             iface = obj[ifaceName];
+            if (!iface || !Array.isArray(iface) || !iface[0]) {
+              continue;
+            }
             for (const methodName of Object.keys(iface[0].methods)) {
               if (methodName === msg.member) {
                 const resultSignature = iface[0].methods[msg.member][1];
@@ -212,15 +215,38 @@ module.exports = function bus(conn, opts) {
           }
         }
       }
-      // setMethodCall handlers
+      /* TODO: in which cases do we have entries in self.methodCallHandlers? The
+       * function this.setMethodCallHandler() is never called in the codebase, but
+       * it is exported, so maybe it is used by some external code. Possibly this is
+       * dead code, though.
+       */
       handler = self.methodCallHandlers[self.mangle(msg)];
       if (handler) {
         invoke(null, handler[0], handler[1]);
       } else {
+        /* TODO: we repeat some conditional logic from earlier in this
+         * function, maybe we can unify it.
+         */
+        let error;
+        let toCheck = '??';
+        const obj = self.exportedObjects[msg.path];
+        if (obj === undefined) {
+          error = 'org.freedesktop.DBus.Error.UnknownObject';
+          toCheck = 'path';
+        } else {
+          const iface = obj[msg['interface']];
+          if (iface === undefined) {
+            error = 'org.freedesktop.DBus.Error.UnknownInterface';
+            toCheck = 'interface';
+          } else {
+            error = 'org.freedesktop.DBus.Error.UnknownMethod';
+            toCheck = 'member';
+          }
+        }
         self.sendError(
           msg,
-          'org.freedesktop.DBus.Error.UnknownService',
-          'Uh oh oh'
+          error,
+          `Unable to handle method call, check ${toCheck}.`
         );
       }
     }

--- a/lib/bus.js
+++ b/lib/bus.js
@@ -212,15 +212,35 @@ module.exports = function bus(conn, opts) {
           }
         }
       }
-      // setMethodCall handlers
+      /* TODO: in which cases do we have entries in self.methodCallHandlers? The
+       * function this.setMethodCallHandler() is never called in the codebase, but
+       * it is exported, so maybe it is used by some external code.
+       */
       handler = self.methodCallHandlers[self.mangle(msg)];
       if (handler) {
         invoke(null, handler[0], handler[1]);
       } else {
+        /* TODO: we repeat some conditional logic from earlier in this
+         * function, maybe we can unify it.
+         */
+        let error;
+        const obj = self.exportedObjects[msg.path];
+        if (obj === undefined) {
+          error = 'org.freedesktop.DBus.Error.UnknownObject';
+        } else {
+          const iface = obj[msg['interface']];
+          if (iface === undefined) {
+            error = 'org.freedesktop.DBus.Error.UnknownInterface';
+          } else {
+            error = 'org.freedesktop.DBus.Error.UnknownMethod';
+          }
+        }
         self.sendError(
           msg,
-          'org.freedesktop.DBus.Error.UnknownService',
-          'Uh oh oh'
+          error,
+          `Unable to handle method call for path=${msg.path}, interface=${
+            msg['interface']
+          }, member=${msg.member}`
         );
       }
     }

--- a/lib/bus.js
+++ b/lib/bus.js
@@ -212,35 +212,15 @@ module.exports = function bus(conn, opts) {
           }
         }
       }
-      /* TODO: in which cases do we have entries in self.methodCallHandlers? The
-       * function this.setMethodCallHandler() is never called in the codebase, but
-       * it is exported, so maybe it is used by some external code.
-       */
+      // setMethodCall handlers
       handler = self.methodCallHandlers[self.mangle(msg)];
       if (handler) {
         invoke(null, handler[0], handler[1]);
       } else {
-        /* TODO: we repeat some conditional logic from earlier in this
-         * function, maybe we can unify it.
-         */
-        let error;
-        const obj = self.exportedObjects[msg.path];
-        if (obj === undefined) {
-          error = 'org.freedesktop.DBus.Error.UnknownObject';
-        } else {
-          const iface = obj[msg['interface']];
-          if (iface === undefined) {
-            error = 'org.freedesktop.DBus.Error.UnknownInterface';
-          } else {
-            error = 'org.freedesktop.DBus.Error.UnknownMethod';
-          }
-        }
         self.sendError(
           msg,
-          error,
-          `Unable to handle method call for path=${msg.path}, interface=${
-            msg['interface']
-          }, member=${msg.member}`
+          'org.freedesktop.DBus.Error.UnknownService',
+          'Uh oh oh'
         );
       }
     }

--- a/test/bus.js
+++ b/test/bus.js
@@ -68,13 +68,11 @@ describe('given a bus', function() {
       assert.deepStrictEqual(getLatestMessageReceived(), {
         type: 3,
         serial: 2,
-        errorName: 'org.freedesktop.DBus.Error.UnknownObject',
+        errorName: 'org.freedesktop.DBus.Error.UnknownService',
         destination: undefined,
         replySerial: undefined,
         signature: 's',
-        body: [
-          'Unable to handle method call for path=undefined, interface=undefined, member=undefined'
-        ]
+        body: ['Uh oh oh']
       });
 
       busInstance.connection.emit('message', {
@@ -87,13 +85,11 @@ describe('given a bus', function() {
       assert.deepStrictEqual(getLatestMessageReceived(), {
         type: 3,
         serial: 3,
-        errorName: 'org.freedesktop.DBus.Error.UnknownObject',
+        errorName: 'org.freedesktop.DBus.Error.UnknownService',
         destination: undefined,
         replySerial: undefined,
         signature: 's',
-        body: [
-          'Unable to handle method call for path=/object1, interface=interface1, member=nonExistingMethod'
-        ]
+        body: ['Uh oh oh']
       });
 
       busInstance.exportedObjects.object1 = {
@@ -246,13 +242,11 @@ describe('given a bus', function() {
       assert.deepStrictEqual(connection.messagesReceived[2], {
         type: 3,
         serial: 3,
-        errorName: 'org.freedesktop.DBus.Error.UnknownObject',
+        errorName: 'org.freedesktop.DBus.Error.UnknownService',
         destination: undefined,
         replySerial: undefined,
         signature: 's',
-        body: [
-          'Unable to handle method call for path=undefined, interface=undefined, member=undefined'
-        ]
+        body: ['Uh oh oh']
       });
 
       // assert.strictEqual(busInstance.state, 'connected');

--- a/test/bus.js
+++ b/test/bus.js
@@ -1,7 +1,74 @@
+const EventEmitter = require('events');
 const bus = require('../lib/bus');
 const assert = require('assert');
 
 describe('given a bus', function() {
+  describe('when sending a message', function() {
+    it('should send the message to the stream', async function() {
+      /* TODO: This is not a useful test yet. It does trigger
+       * an UnknownService error, though, which we ultimately
+       * want to fix.
+       */
+
+      let messageSent = null;
+      let busInstance = null;
+
+      // fake stream implementation, it captures the message sent to it
+      const stream = {
+        write: (msg, cb) => {
+          if (msg.member === 'Hello') {
+            return; // we ignore the 'Hello' message
+          }
+          messageSent = msg;
+          process.nextTick(() => {
+            if (cb) {
+              cb(null); // simulate successful write
+            } else {
+              console.warn(
+                'No callback provided to stream.write, msg= ' +
+                  JSON.stringify(msg)
+              );
+            }
+          });
+        }
+      };
+
+      // instantiate a bus with the fake stream
+      const connection = new EventEmitter();
+      connection.stream = stream;
+      connection.message = (msg, cb) => stream.write(msg, cb);
+
+      busInstance = bus(connection);
+
+      // invoke the bus to send a message
+      await new Promise(resolve => {
+        busInstance.invoke(
+          {
+            bla: 42
+          },
+          function(err) {
+            assert.ifError(err);
+          }
+        );
+        resolve();
+      });
+
+      // assert that the message was sent to the stream
+      assert(messageSent);
+      assert.strictEqual(messageSent.bla, 42);
+
+      // simulate an incoming response
+      busInstance.connection.emit('message', { response: 'ok' });
+
+      // assert that the bus emits the response message
+      busInstance.connection.on('message', function(msg) {
+        assert.deepStrictEqual(msg, { response: 'ok' });
+      });
+
+      // assert.strictEqual(busInstance.state, 'connected');
+    });
+  });
+
   it('sending a message fails if writing to the stream fails', async function() {
     // fake stream implementation, it fails on write
     const stream = {

--- a/test/bus.js
+++ b/test/bus.js
@@ -4,10 +4,135 @@ const assert = require('assert');
 
 describe('given a bus', function() {
   describe('when sending a message', function() {
+    it('should send the message to the stream and handle error scenarios', async function() {
+      let messageSent = null;
+      let busInstance = null;
+
+      // fake stream implementation, it captures the message sent to it
+      const stream = {
+        messagesReceived: [],
+        messagesReceivedWithoutCallback: [],
+        messagesWithoutCallbackHandlers: [],
+        write: (msg, cb) => {
+          if (msg.member === 'Hello') {
+            return; // we ignore the 'Hello' message
+          }
+          messageSent = msg;
+          process.nextTick(() => {
+            if (cb) {
+              console.warn(
+                `Stream write called with msg= ${JSON.stringify(msg)}`
+              );
+              stream.messagesReceived.push(msg);
+              cb(null); // simulate successful write
+            } else {
+              console.warn(
+                'No callback provided to stream.write, msg= ' +
+                  JSON.stringify(msg)
+              );
+              stream.messagesReceivedWithoutCallback.push(msg);
+              for (const handler of stream.messagesWithoutCallbackHandlers) {
+                handler(msg);
+              }
+            }
+          });
+        }
+      };
+
+      function getLatestMessageReceived() {
+        if (connection.messagesReceived.length === 0) {
+          return null;
+        }
+        return connection.messagesReceived[
+          connection.messagesReceived.length - 1
+        ];
+      }
+
+      // instantiate a bus with the fake stream
+      const connection = new EventEmitter();
+      connection.stream = stream;
+      connection.messagesReceived = [];
+      connection.message = (msg, cb) => {
+        console.warn(`Bus message called with msg= ${JSON.stringify(msg)}`);
+        connection.messagesReceived.push(msg);
+        stream.write(msg, cb);
+      };
+
+      busInstance = bus(connection);
+
+      assert.strictEqual(connection.messagesReceived.length, 1);
+
+      busInstance.connection.emit('message', { bla: 42 });
+
+      assert.strictEqual(connection.messagesReceived.length, 2);
+      assert.deepStrictEqual(getLatestMessageReceived(), {
+        type: 3,
+        serial: 2,
+        errorName: 'org.freedesktop.DBus.Error.UnknownObject',
+        destination: undefined,
+        replySerial: undefined,
+        signature: 's',
+        body: [
+          'Unable to handle method call for path=undefined, interface=undefined, member=undefined'
+        ]
+      });
+
+      busInstance.connection.emit('message', {
+        path: '/object1',
+        interface: 'interface1',
+        member: 'nonExistingMethod'
+      });
+
+      assert.strictEqual(connection.messagesReceived.length, 3);
+      assert.deepStrictEqual(getLatestMessageReceived(), {
+        type: 3,
+        serial: 3,
+        errorName: 'org.freedesktop.DBus.Error.UnknownObject',
+        destination: undefined,
+        replySerial: undefined,
+        signature: 's',
+        body: [
+          'Unable to handle method call for path=/object1, interface=interface1, member=nonExistingMethod'
+        ]
+      });
+
+      busInstance.exportedObjects.object1 = {
+        interface1: [
+          null,
+          {
+            methods: {
+              method1: function(arg, cb) {
+                console.warn(`method1 called with arg= ${JSON.stringify(arg)}`);
+                cb(null, 'result1');
+              }
+            }
+          }
+        ]
+      };
+
+      busInstance.connection.emit('message', {
+        path: 'object1',
+        interface: 'interface1',
+        member: 'nonExistingMethod'
+      });
+
+      assert.strictEqual(connection.messagesReceived.length, 4);
+      assert.deepStrictEqual(getLatestMessageReceived(), {
+        type: 3,
+        serial: 4,
+        errorName: 'org.freedesktop.DBus.Error.UnknownMethod',
+        destination: undefined,
+        replySerial: undefined,
+        signature: 's',
+        body: [
+          'Method "nonExistingMethod" on interface "interface1" doesn\'t exist'
+        ]
+      });
+    });
+
     it('should send the message to the stream', async function() {
-      /* TODO: This is not a useful test yet. It does trigger
-       * an UnknownService error, though, which we ultimately
-       * want to fix.
+      /* TODO: This is probably not a useful test, as using busInstance.invoke()
+       * seems to be the wrong entry point into processing a message received.
        */
 
       let messageSent = null;
@@ -78,17 +203,6 @@ describe('given a bus', function() {
 
       // invoke the bus to send a message
       await invokeBus({ bla: 42 });
-      // await new Promise(resolve => {
-      //   busInstance.invoke(
-      //     {
-      //       bla: 42
-      //     },
-      //     function(err) {
-      //       assert.ifError(err);
-      //     }
-      //   );
-      //   resolve();
-      // });
 
       // assert that the message was sent to the stream
       assert(messageSent);
@@ -117,6 +231,7 @@ describe('given a bus', function() {
       // assert.deepStrictEqual(connection.messagesReceived[2], { type: 3, serial: 3, errorName: 'org.freedesktop.DBus.Error.UnknownObject', });
 
       // simulate an incoming response
+      // TODO: maybe this is how we should test messages to non-existing objects/interfaces/methods?
       busInstance.connection.emit('message', { response: 'ok' });
 
       // assert that the bus emits the response message
@@ -149,6 +264,49 @@ describe('given a bus', function() {
           cb(null, 'result1');
         }
       };
+
+      // failure condition: calling a method that does not exist on an object that does exist.
+      await invokeBus({
+        path: '/object1',
+        interface: 'interface1',
+        member: 'nonExistingMethod'
+      });
+
+      assert.strictEqual(connection.messagesReceived.length, 4);
+      // TODO: why are we not getting an error now?
+      assert.deepStrictEqual(connection.messagesReceived[3], {
+        type: 1,
+        serial: 4,
+        // errorName: 'org.freedesktop.DBus.Error.UnknownMethod',
+        // destination: undefined,
+        // replySerial: undefined,
+        // signature: "s",
+        interface: 'interface1',
+        member: 'nonExistingMethod',
+        path: '/object1'
+        // body: [
+        //   "Unable to handle method call for path=/object1, interface=interface1, member=nonExistingMethod"
+        // ]
+      });
+
+      // simulate an incoming response
+      busInstance.connection.emit('message', { response: 'ok' });
+
+      assert.strictEqual(connection.messagesReceived.length, 5);
+      // assert.deepStrictEqual(connection.messagesReceived[4], {
+      //   type: 3,
+      //   serial: 5,
+      //   errorName: 'org.freedesktop.DBus.Error.UnknownMethod',
+      //   destination: undefined,
+      //   replySerial: undefined,
+      //   signature: "s",
+      //   interface: 'interface1',
+      //   member: 'nonExistingMethod',
+      //   path: '/object1',
+      //   body: [
+      //     "Unable to handle method call for path=/object1, interface=interface1, member=nonExistingMethod"
+      //   ]
+      // });
     });
   });
 

--- a/test/bus.js
+++ b/test/bus.js
@@ -1,6 +1,7 @@
 const EventEmitter = require('events');
 const bus = require('../lib/bus');
 const assert = require('assert');
+const debug = require('debug')('dbus-native-victron:bus-test');
 
 describe('given a bus', function() {
   describe('when sending a message', function() {
@@ -20,13 +21,11 @@ describe('given a bus', function() {
           messageSent = msg;
           process.nextTick(() => {
             if (cb) {
-              console.warn(
-                `Stream write called with msg= ${JSON.stringify(msg)}`
-              );
+              debug(`Stream write called with msg= ${JSON.stringify(msg)}`);
               stream.messagesReceived.push(msg);
               cb(null); // simulate successful write
             } else {
-              console.warn(
+              debug(
                 'No callback provided to stream.write, msg= ' +
                   JSON.stringify(msg)
               );
@@ -53,7 +52,7 @@ describe('given a bus', function() {
       connection.stream = stream;
       connection.messagesReceived = [];
       connection.message = (msg, cb) => {
-        console.warn(`Bus message called with msg= ${JSON.stringify(msg)}`);
+        debug(`Bus message called with msg= ${JSON.stringify(msg)}`);
         connection.messagesReceived.push(msg);
         stream.write(msg, cb);
       };
@@ -68,15 +67,15 @@ describe('given a bus', function() {
       assert.deepStrictEqual(getLatestMessageReceived(), {
         type: 3,
         serial: 2,
-        errorName: 'org.freedesktop.DBus.Error.UnknownService',
+        errorName: 'org.freedesktop.DBus.Error.UnknownObject',
         destination: undefined,
         replySerial: undefined,
         signature: 's',
-        body: ['Uh oh oh']
+        body: ['Unable to handle method call, check path.']
       });
 
       busInstance.connection.emit('message', {
-        path: '/object1',
+        path: 'non-existing-path',
         interface: 'interface1',
         member: 'nonExistingMethod'
       });
@@ -85,11 +84,11 @@ describe('given a bus', function() {
       assert.deepStrictEqual(getLatestMessageReceived(), {
         type: 3,
         serial: 3,
-        errorName: 'org.freedesktop.DBus.Error.UnknownService',
+        errorName: 'org.freedesktop.DBus.Error.UnknownObject',
         destination: undefined,
         replySerial: undefined,
         signature: 's',
-        body: ['Uh oh oh']
+        body: ['Unable to handle method call, check path.']
       });
 
       busInstance.exportedObjects.object1 = {
@@ -98,7 +97,7 @@ describe('given a bus', function() {
           {
             methods: {
               method1: function(arg, cb) {
-                console.warn(`method1 called with arg= ${JSON.stringify(arg)}`);
+                debug(`method1 called with arg= ${JSON.stringify(arg)}`);
                 cb(null, 'result1');
               }
             }
@@ -124,11 +123,28 @@ describe('given a bus', function() {
           'Method "nonExistingMethod" on interface "interface1" doesn\'t exist'
         ]
       });
+
+      busInstance.connection.emit('message', {
+        path: 'object1',
+        interface: 'interface2',
+        member: 'nonExistingMethod'
+      });
+
+      assert.strictEqual(connection.messagesReceived.length, 5);
+      assert.deepStrictEqual(getLatestMessageReceived(), {
+        type: 3,
+        serial: 5,
+        errorName: 'org.freedesktop.DBus.Error.UnknownInterface',
+        destination: undefined,
+        replySerial: undefined,
+        signature: 's',
+        body: ['Unable to handle method call, check interface.']
+      });
     });
 
     it('should send the message to the stream', async function() {
-      /* TODO: This is probably not a useful test, as using busInstance.invoke()
-       * seems to be the wrong entry point into processing a message received.
+      /* TODO: This is a problematic unit test, as using busInstance.invoke()
+       * results in some odd call paths. We leave the test here to aid future refactoring.
        */
 
       let messageSent = null;
@@ -146,13 +162,11 @@ describe('given a bus', function() {
           messageSent = msg;
           process.nextTick(() => {
             if (cb) {
-              console.warn(
-                `Stream write called with msg= ${JSON.stringify(msg)}`
-              );
+              debug(`Stream write called with msg= ${JSON.stringify(msg)}`);
               stream.messagesReceived.push(msg);
               cb(null); // simulate successful write
             } else {
-              console.warn(
+              debug(
                 'No callback provided to stream.write, msg= ' +
                   JSON.stringify(msg)
               );
@@ -170,7 +184,7 @@ describe('given a bus', function() {
       connection.stream = stream;
       connection.messagesReceived = [];
       connection.message = (msg, cb) => {
-        console.warn(`Bus message called with msg= ${JSON.stringify(msg)}`);
+        debug(`Bus message called with msg= ${JSON.stringify(msg)}`);
         connection.messagesReceived.push(msg);
         stream.write(msg, cb);
       };
@@ -178,18 +192,18 @@ describe('given a bus', function() {
       busInstance = bus(connection);
 
       // connection.stream.on('message', function(msg) {
-      //   console.warn(`Stream received message: ${JSON.stringify(msg)}`);
+      //   debug(`Stream received message: ${JSON.stringify(msg)}`);
       // });
 
       function invokeBus(msg) {
         return new Promise((resolve, reject) => {
           busInstance.invoke(msg, function(err) {
             if (err) {
-              console.warn(
+              debug(
                 `Bus invoke error: ${err.message}, msg=${JSON.stringify(msg)}`
               );
             } else {
-              console.warn(`Bus invoke successful, msg=${JSON.stringify(msg)}`);
+              debug(`Bus invoke successful, msg=${JSON.stringify(msg)}`);
             }
           });
           // note that we resolve *before* the callback is called. Callback does not seem to be called, unless there is an error.
@@ -233,7 +247,7 @@ describe('given a bus', function() {
       // assert that the bus emits the response message
       // TODO: the callback is not being called.
       busInstance.connection.on('message', function(msg) {
-        console.warn(`Received message: ${JSON.stringify(msg)}`);
+        debug(`Received message: ${JSON.stringify(msg)}`);
         assert.deepStrictEqual(msg, { response: 'ok' });
       });
 
@@ -242,19 +256,19 @@ describe('given a bus', function() {
       assert.deepStrictEqual(connection.messagesReceived[2], {
         type: 3,
         serial: 3,
-        errorName: 'org.freedesktop.DBus.Error.UnknownService',
+        errorName: 'org.freedesktop.DBus.Error.UnknownObject',
         destination: undefined,
         replySerial: undefined,
         signature: 's',
-        body: ['Uh oh oh']
+        body: ['Unable to handle method call, check path.']
       });
 
       // assert.strictEqual(busInstance.state, 'connected');
-      console.warn(`Done?`);
+      debug('Done');
 
       busInstance.exportedObjects.object1 = {
         method1: function(arg, cb) {
-          console.warn(`method1 called with arg= ${JSON.stringify(arg)}`);
+          debug(`method1 called with arg= ${JSON.stringify(arg)}`);
           cb(null, 'result1');
         }
       };

--- a/test/bus.js
+++ b/test/bus.js
@@ -15,6 +15,9 @@ describe('given a bus', function() {
 
       // fake stream implementation, it captures the message sent to it
       const stream = {
+        messagesReceived: [],
+        messagesReceivedWithoutCallback: [],
+        messagesWithoutCallbackHandlers: [],
         write: (msg, cb) => {
           if (msg.member === 'Hello') {
             return; // we ignore the 'Hello' message
@@ -22,12 +25,20 @@ describe('given a bus', function() {
           messageSent = msg;
           process.nextTick(() => {
             if (cb) {
+              console.warn(
+                `Stream write called with msg= ${JSON.stringify(msg)}`
+              );
+              stream.messagesReceived.push(msg);
               cb(null); // simulate successful write
             } else {
               console.warn(
                 'No callback provided to stream.write, msg= ' +
                   JSON.stringify(msg)
               );
+              stream.messagesReceivedWithoutCallback.push(msg);
+              for (const handler of stream.messagesWithoutCallbackHandlers) {
+                handler(msg);
+              }
             }
           });
         }
@@ -36,36 +47,108 @@ describe('given a bus', function() {
       // instantiate a bus with the fake stream
       const connection = new EventEmitter();
       connection.stream = stream;
-      connection.message = (msg, cb) => stream.write(msg, cb);
+      connection.messagesReceived = [];
+      connection.message = (msg, cb) => {
+        console.warn(`Bus message called with msg= ${JSON.stringify(msg)}`);
+        connection.messagesReceived.push(msg);
+        stream.write(msg, cb);
+      };
 
       busInstance = bus(connection);
 
+      // connection.stream.on('message', function(msg) {
+      //   console.warn(`Stream received message: ${JSON.stringify(msg)}`);
+      // });
+
+      function invokeBus(msg) {
+        return new Promise((resolve, reject) => {
+          busInstance.invoke(msg, function(err) {
+            if (err) {
+              console.warn(
+                `Bus invoke error: ${err.message}, msg=${JSON.stringify(msg)}`
+              );
+            } else {
+              console.warn(`Bus invoke successful, msg=${JSON.stringify(msg)}`);
+            }
+          });
+          // note that we resolve *before* the callback is called. Callback does not seem to be called, unless there is an error.
+          resolve();
+        });
+      }
+
       // invoke the bus to send a message
-      await new Promise(resolve => {
-        busInstance.invoke(
-          {
-            bla: 42
-          },
-          function(err) {
-            assert.ifError(err);
-          }
-        );
-        resolve();
-      });
+      await invokeBus({ bla: 42 });
+      // await new Promise(resolve => {
+      //   busInstance.invoke(
+      //     {
+      //       bla: 42
+      //     },
+      //     function(err) {
+      //       assert.ifError(err);
+      //     }
+      //   );
+      //   resolve();
+      // });
 
       // assert that the message was sent to the stream
       assert(messageSent);
       assert.strictEqual(messageSent.bla, 42);
 
+      // TODO: strange that we get the message synchronously.
+      assert.strictEqual(stream.messagesReceived.length, 1);
+      assert.deepStrictEqual(stream.messagesReceived[0], {
+        bla: 42,
+        serial: 2,
+        type: 1
+      });
+
+      // TODO: waiting here makes no observeable difference
+      await new Promise(resolve => setTimeout(resolve, 100)); // wait for the message to be processed
+
+      // TODO: I expect the error message to be in 'messagesReceived', but
+      // it only arrives once we emit a message on the connection further down. Why??
+
+      assert.strictEqual(connection.messagesReceived.length, 2);
+      assert.deepStrictEqual(connection.messagesReceived[1], {
+        bla: 42,
+        serial: 2,
+        type: 1
+      });
+      // assert.deepStrictEqual(connection.messagesReceived[2], { type: 3, serial: 3, errorName: 'org.freedesktop.DBus.Error.UnknownObject', });
+
       // simulate an incoming response
       busInstance.connection.emit('message', { response: 'ok' });
 
       // assert that the bus emits the response message
+      // TODO: the callback is not being called.
       busInstance.connection.on('message', function(msg) {
+        console.warn(`Received message: ${JSON.stringify(msg)}`);
         assert.deepStrictEqual(msg, { response: 'ok' });
       });
 
+      // TODO: why is it 3 messages now??
+      assert.strictEqual(connection.messagesReceived.length, 3);
+      assert.deepStrictEqual(connection.messagesReceived[2], {
+        type: 3,
+        serial: 3,
+        errorName: 'org.freedesktop.DBus.Error.UnknownObject',
+        destination: undefined,
+        replySerial: undefined,
+        signature: 's',
+        body: [
+          'Unable to handle method call for path=undefined, interface=undefined, member=undefined'
+        ]
+      });
+
       // assert.strictEqual(busInstance.state, 'connected');
+      console.warn(`Done?`);
+
+      busInstance.exportedObjects.object1 = {
+        method1: function(arg, cb) {
+          console.warn(`method1 called with arg= ${JSON.stringify(arg)}`);
+          cb(null, 'result1');
+        }
+      };
     });
   });
 


### PR DESCRIPTION
Addresses #2, i.e error handling in the dbus implementation, if path or interface or method do not exist:

- We now use the correct error name `org.freedesktop.DBus.Error.UnknownMethod` etc.
- We replace the error message "Uh oh oh" with something more meaningful, hinting at the cause of the error.

The unit tests are "interesting", as they show some odd call paths, see [here](https://github.com/Chris927/dbus-native/blob/6917a0d1fc87598a5fe87d407e8f2e678c1c097a/test/bus.js#L229-L233). We leave some TODOs and comments in there, to aid future refactoring.

In addition, this fixes a possible crash, dereferencing `null` or `undefined` on `iface[0].methods`.