### PR TITLE
Do not crash if callback is an object

### DIFF
--- a/lib/bus.js
+++ b/lib/bus.js
@@ -7,6 +7,11 @@ const stdDbusIfaces = require('./stdifaces');
 const introspect = require('./introspect').introspectBus;
 
 module.exports = function bus(conn, opts, constructorCallback) {
+  console.log(
+    `[CHRIS-DEBUG] bus constructor called with constructorCallback=${constructorCallback}, opts=${JSON.stringify(
+      opts
+    )}`
+  );
   if (!(this instanceof bus)) {
     return new bus(conn, opts, constructorCallback);
   }
@@ -450,7 +455,7 @@ module.exports = function bus(conn, opts, constructorCallback) {
 
   // helper function to call constructorCallback consistently.
   function doCallback(err, result) {
-    if (constructorCallback) {
+    if (typeof constructorCallback === 'function') {
       process.nextTick(function() {
         constructorCallback(err, result);
       });

--- a/lib/bus.js
+++ b/lib/bus.js
@@ -1,3 +1,4 @@
+const debug = require('debug')('dbus-native-victron:bus');
 const debugLogAllMessages = require('debug')(
   'dbus-native-victron:log-all-messages'
 );
@@ -7,8 +8,8 @@ const stdDbusIfaces = require('./stdifaces');
 const introspect = require('./introspect').introspectBus;
 
 module.exports = function bus(conn, opts, constructorCallback) {
-  console.log(
-    `[CHRIS-DEBUG] bus constructor called with constructorCallback=${constructorCallback}, opts=${JSON.stringify(
+  debug(
+    `constructor called with constructorCallback=${constructorCallback}, opts=${JSON.stringify(
       opts
     )}`
   );


### PR DESCRIPTION
Depending on how the bus constructor is called, the `constructorCallback` argument may be an object, instead of a function.

Previously, we would try to call anyway (`if (constructorCallback) ...`), now we check first that `constructorCallback` is actually a function.

In addition, there is now some debug() logging concerning the constructor arguments, which was handy while debugging this issue.